### PR TITLE
Update Send-DHCPAlerts.ps1

### DIFF
--- a/Send-DHCPAlerts.ps1
+++ b/Send-DHCPAlerts.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
     .SYNOPSIS 
       Sends alerts based on certain DHCP events or configurations
     .Example
@@ -20,6 +20,7 @@ TD {border-width: 1px; padding: 3px; border-style: solid; border-color: black;}
 "@
   $datetime= Get-Date #| Out-String
   $LeaseInfo = Get-DhcpServerv4Lease -scopeID $scope -ComputerName $DhcpServer | select -Property ClientID, Hostname, AddressState | where {$_.AddressState -eq "Active"}
+  $LeaseInfo.ClientID = $LeaseInfo.ClientID -replace '-',''
   $Body = $LeaseInfo | ConvertTo-Html -Head $Header
   IF (!$LogFilePath) {$LogFilePath = (Get-Item -Path ".\").FullName}
       IF ($LeaseInfo) 


### PR DESCRIPTION
Added line 23 ($LeaseInfo.ClientID = $LeaseInfo.ClientID -replace '-','') to replace the '-' with '' to allow for copy and paste of ClientID (MAC address) into DHCP reservation.

Thanks Dylan.  Now we can copy/paste right from the notification emails into the dhcp reservation.